### PR TITLE
Allow passing video constraints

### DIFF
--- a/custom_components/reflex_webcam/webcam.py
+++ b/custom_components/reflex_webcam/webcam.py
@@ -32,6 +32,8 @@ class Webcam(rx.Component):
     # show camera preview and get the screenshot mirrored
     mirrored: Var[bool] = False
 
+    # allow passing video constraints such as facingMode
+    video_constraints: Var[dict] = {}
 
     special_props: set[Var] = [Var.create("muted")]
 


### PR DESCRIPTION
In order to be able to pass videoConstraints such as `facingMode`, `height` or `deviceId` (see examples here https://www.npmjs.com/package/react-webcam) the state variable `video_constraints: Var[dict] = {}` is added.

This allows e.g. to request either the inner or outer camera of a phone, or introduce a "flip" button that allows switching between the two cameras: 
```
webcam.webcam(
            id=ref,
            video_constraints=rx.cond(
                CameraState.use_outer_camera,
                {
                    "facingMode": "environment",
                },
                {
                    "facingMode": "user",
                },
            ),
        ),
```

If only the selfie cam should be allowed (e.g. for a KYC process) then you can set the constraints to `exact`:
```
webcam.webcam(
            id=ref,
            video_constraints={"facingMode": {"exact": "user"}}
        ),
```

Beware that setting ` video_constraints={"facingMode": {"exact": "environment"}}` will result that you can't take a picture with a webcam on a laptop because a laptop typically doesn't have an outer (environment) camera.
